### PR TITLE
```

### DIFF
--- a/client/src/components/AddAssetModal.tsx
+++ b/client/src/components/AddAssetModal.tsx
@@ -51,8 +51,8 @@ export function AddAssetModal({
       const assetData: NewAsset = {
         name,
         currency,
-        target_percentage: parseFloat(targetPercentage),
-        current_value: parseFloat(currentValue),
+        target_percentage: Number.parseFloat(targetPercentage),
+        current_value: Number.parseFloat(currentValue),
       };
 
       if (assetToEdit) {


### PR DESCRIPTION
refactor: use Number.parseFloat instead of parseFloat in AddAssetModal

Changed parseFloat calls to Number.parseFloat for target_percentage and current_value fields to use the more explicit Number method syntax.
```