### PR TITLE
refactor: improve accessibility in RebalanceDrawer and DashboardPage

### DIFF
--- a/client/src/components/RebalanceDrawer.tsx
+++ b/client/src/components/RebalanceDrawer.tsx
@@ -61,7 +61,7 @@ export function RebalanceDrawer({ show, onClose }: RebalanceDrawerProps) {
   return (
     <>
       {/* Backdrop - Click to close */}
-      <div className={`drawer-backdrop ${show ? 'show' : ''}`} onClick={onClose}></div>
+      <div className={`drawer-backdrop ${show ? 'show' : ''}`} onClick={onClose} aria-hidden="true"></div>
 
       {/* The Sliding Drawer */}
       <div className={`drawer ${show ? 'show' : ''}`}>
@@ -86,7 +86,7 @@ export function RebalanceDrawer({ show, onClose }: RebalanceDrawerProps) {
               </p>
 
               <div className="mb-4">
-                <label className="form-label fw-bold">Contribution Amount</label>
+                <div className="form-label fw-bold">Contribution Amount</div>
                 <div className="input-group input-group-lg shadow-sm">
                   <span className="input-group-text bg-white text-muted">
                     {currency === 'BRL' ? 'R$' : '$'}
@@ -106,7 +106,7 @@ export function RebalanceDrawer({ show, onClose }: RebalanceDrawerProps) {
               </div>
 
               <div className="mb-4">
-                <label className="form-label fw-bold">Source Currency</label>
+                <div className="form-label fw-bold">Source Currency</div>
                 <div className="d-flex gap-3">
                   <button
                     type="button"

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -121,8 +121,10 @@ export function DashboardPage() {
             className="btn btn-primary btn-lg px-5 py-3 shadow-lg d-flex align-items-center gap-3 rounded-pill hover-scale"
             onClick={() => setShowRebalanceDrawer(true)}
             style={{ transition: 'transform 0.2s' }}
-            onMouseOver={(e) => (e.currentTarget.style.transform = 'scale(1.02)')}
+            onMouseOver={(e) => (e.currentTarget.style.transform = 'scale(1.05)')}
+            onFocus={(e) => (e.currentTarget.style.transform = 'scale(1.05)')}
             onMouseOut={(e) => (e.currentTarget.style.transform = 'scale(1)')}
+            onBlur={(e) => (e.currentTarget.style.transform = 'scale(1)')}
           >
             <i className="bi bi-stars fs-3"></i> {/* Changed icon to "stars" for a "magic" feel */}
             <div className="text-start">


### PR DESCRIPTION
refactor: improve accessibility in RebalanceDrawer and DashboardPage

Added aria-hidden="true" to drawer backdrop for better screen reader support. Replaced label elements with div elements for non-input form labels in RebalanceDrawer. Enhanced rebalance button with onFocus and onBlur handlers for keyboard navigation, and increased hover/focus scale from 1.02 to 1.05.
```