### PR TITLE
refactor: add Readonly type wrapper to component props

### DIFF
--- a/client/src/components/AddAssetModal.tsx
+++ b/client/src/components/AddAssetModal.tsx
@@ -9,7 +9,7 @@ interface AddAssetModalProps {
   assetToEdit?: Asset | null;
 }
 
-export function AddAssetModal({ show, onClose, onAssetSaved, assetToEdit }: AddAssetModalProps) {
+export function AddAssetModal({ show, onClose, onAssetSaved, assetToEdit }: Readonly<AddAssetModalProps>) {
   const [name, setName] = useState('');
   const [currency, setCurrency] = useState<'USD' | 'BRL'>('BRL');
   const [targetPercentage, setTargetPercentage] = useState('');

--- a/client/src/components/PortfolioCharts.tsx
+++ b/client/src/components/PortfolioCharts.tsx
@@ -18,7 +18,7 @@ interface PortfolioChartsProps {
   assets: Asset[];
 }
 
-export function PortfolioCharts({ assets }: PortfolioChartsProps) {
+export function PortfolioCharts({ assets }: Readonly<PortfolioChartsProps>) {
   if (assets.length === 0) return null;
 
 const ESTIMATED_USD_RATE = 6;

--- a/client/src/components/ProtectedRoute.tsx
+++ b/client/src/components/ProtectedRoute.tsx
@@ -5,7 +5,7 @@ interface ProtectedRouteProps {
   children: React.ReactNode;
 }
 
-export function ProtectedRoute({ children }: ProtectedRouteProps) {
+export function ProtectedRoute({ children }: Readonly<ProtectedRouteProps>) {
   const token = localStorage.getItem('token');
 
   if (!token) {

--- a/client/src/components/RebalanceDrawer.tsx
+++ b/client/src/components/RebalanceDrawer.tsx
@@ -7,7 +7,7 @@ interface RebalanceDrawerProps {
   onClose: () => void;
 }
 
-export function RebalanceDrawer({ show, onClose }: RebalanceDrawerProps) {
+export function RebalanceDrawer({ show, onClose }: Readonly<RebalanceDrawerProps>) {
   // UI State
   const [step, setStep] = useState<'INPUT' | 'RESULT'>('INPUT');
   const [loading, setLoading] = useState(false);


### PR DESCRIPTION
refactor: add Readonly type wrapper to component props

Added Readonly type wrapper to props destructuring in AddAssetModal, PortfolioCharts, ProtectedRoute, and RebalanceDrawer components to prevent accidental prop mutations.
```