### PR TITLE
fix(sonarqube): resolve nested ternary and group role accessibility warnings

### DIFF
--- a/client/src/components/AddAssetModal.tsx
+++ b/client/src/components/AddAssetModal.tsx
@@ -67,6 +67,13 @@ export function AddAssetModal({
     }
   };
 
+  let submitButtonText = 'Save Asset';
+  if (isSubmitting) {
+    submitButtonText = 'Saving...';
+  } else if (assetToEdit) {
+    submitButtonText = 'Update Asset';
+  }
+
   return (
     <Modal show={show} onClose={onClose} title={assetToEdit ? 'Edit Asset' : 'Add New Asset'}>
       {error && <div className="alert alert-danger">{error}</div>}
@@ -136,7 +143,7 @@ export function AddAssetModal({
             Cancel
           </button>
           <button type="submit" className="btn btn-primary" disabled={isSubmitting}>
-            {isSubmitting ? 'Saving...' : assetToEdit ? 'Update Asset' : 'Save Asset'}
+            {submitButtonText}
           </button>
         </div>
       </form>

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -226,7 +226,7 @@ export function DashboardPage() {
                       {formatCurrency(Number(asset.current_value), asset.currency)}
                     </td>
                     <td className="text-end pe-4">
-                      <div className="btn-group shadow-sm" role="group">
+                      <div className="btn-group shadow-sm">
                         <button
                           className="btn btn-sm btn-outline-secondary bg-white"
                           title="Edit Asset"


### PR DESCRIPTION
This PR fixes the SonarQube issues identified in `AddAssetModal.tsx` and `DashboardPage.tsx`:
- Refactors the nested ternary in `AddAssetModal`'s submit button text into an independent statement using if-else logic.
- Removes the non-semantic `role="group"` from the action buttons `div` in `DashboardPage` to resolve the accessibility warning.