### PR TITLE
feat: Restructure account settings modal with split-view layout and security improvements

### DIFF
--- a/client/src/components/AccountSettings/AccountSettingsModal.tsx
+++ b/client/src/components/AccountSettings/AccountSettingsModal.tsx
@@ -1,15 +1,102 @@
+import { useEffect, useState } from 'react';
 import { Modal } from '../ModalLayout';
 import { DeleteAccountSection } from './DeleteAccountSection';
 import { UpdateEmailForm } from './UpdateEmailForm';
 import { UpdatePasswordForm } from './UpdatePasswordForm';
+import userService from '../../services/userService';
 
 export function AccountSettingsModal({ show, onClose }: Readonly<{ show: boolean; onClose: () => void }>) {
+  const [activeTab, setActiveTab] = useState<'profile' | 'security' | 'danger'>('profile');
+  const [currentUserEmail, setCurrentUserEmail] = useState<string>('');
+  const [isLoadingProfile, setIsLoadingProfile] = useState<boolean>(false);
+  const [profileError, setProfileError] = useState<string | null>(null);
+
+  const fetchProfile = async () => {
+    try {
+      setIsLoadingProfile(true);
+      setProfileError(null);
+      const data = await userService.getProfile();
+      setCurrentUserEmail(data.email);
+    } catch (err) {
+      setProfileError('Failed to load user profile. Please try again.');
+    } finally {
+      setIsLoadingProfile(false);
+    }
+  };
+
+  useEffect(() => {
+    if (show) {
+      fetchProfile();
+      setActiveTab('profile');
+    }
+  }, [show]);
+
+  const handleEmailUpdated = (newEmail: string) => {
+    setCurrentUserEmail(newEmail);
+  };
+
   return (
-    <Modal show={show} onClose={onClose} title="Account Settings">
-      <div className="d-flex flex-column gap-4">
-        <UpdateEmailForm />
-        <UpdatePasswordForm />
-        <DeleteAccountSection />
+    <Modal show={show} onClose={onClose} title="Account Settings" size="lg">
+      <div className="d-flex gap-4" style={{ minHeight: '380px' }}>
+        {/* Navigation Sidebar */}
+        <div 
+          className="d-flex flex-column gap-2 border-end pe-3" 
+          style={{ width: '220px', flexShrink: 0 }}
+        >
+          <button
+            type="button"
+            onClick={() => setActiveTab('profile')}
+            className={`btn text-start w-100 px-3 d-flex align-items-center fw-medium ${
+              activeTab === 'profile' ? 'btn-primary text-white' : 'btn-light text-secondary border'
+            }`}
+            style={{ minHeight: '44px', borderRadius: '8px', transition: 'all 0.2s' }}
+          >
+            Email & Profile
+          </button>
+          <button
+            type="button"
+            onClick={() => setActiveTab('security')}
+            className={`btn text-start w-100 px-3 d-flex align-items-center fw-medium ${
+              activeTab === 'security' ? 'btn-primary text-white' : 'btn-light text-secondary border'
+            }`}
+            style={{ minHeight: '44px', borderRadius: '8px', transition: 'all 0.2s' }}
+          >
+            Security & Password
+          </button>
+          <button
+            type="button"
+            onClick={() => setActiveTab('danger')}
+            className={`btn text-start w-100 px-3 d-flex align-items-center fw-medium ${
+              activeTab === 'danger' ? 'btn-danger text-white' : 'btn-light text-danger border border-danger-subtle'
+            }`}
+            style={{ minHeight: '44px', borderRadius: '8px', transition: 'all 0.2s' }}
+          >
+            Account Settings
+          </button>
+        </div>
+
+        {/* Content Panel */}
+        <div className="flex-grow-1 ps-2" style={{ minWidth: 0 }}>
+          {isLoadingProfile ? (
+            <div className="d-flex justify-content-center align-items-center h-100 py-5">
+              <div className="spinner-border text-primary" role="status">
+                <span className="visually-hidden">Loading profile...</span>
+              </div>
+            </div>
+          ) : profileError ? (
+            <div className="alert alert-danger py-2 px-3 small">{profileError}</div>
+          ) : (
+            <div className="h-100">
+              {activeTab === 'profile' && (
+                <UpdateEmailForm currentEmail={currentUserEmail} onSuccess={handleEmailUpdated} />
+              )}
+              {activeTab === 'security' && <UpdatePasswordForm />}
+              {activeTab === 'danger' && (
+                <DeleteAccountSection currentUserEmail={currentUserEmail} />
+              )}
+            </div>
+          )}
+        </div>
       </div>
     </Modal>
   );

--- a/client/src/components/AccountSettings/DeleteAccountSection.tsx
+++ b/client/src/components/AccountSettings/DeleteAccountSection.tsx
@@ -1,76 +1,127 @@
-import userService from '../../services/userService';
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import userService from '../../services/userService';
+import { getErrorMessage } from '../../utils/errorHandler';
 
-const useDeleteAccount = () => {
+interface DeleteAccountSectionProps {
+  currentUserEmail: string;
+}
+
+export function DeleteAccountSection({ currentUserEmail }: Readonly<DeleteAccountSectionProps>) {
+  const [typedEmail, setTypedEmail] = useState('');
   const [password, setPassword] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const [emailTouched, setEmailTouched] = useState(false);
+  const [passwordTouched, setPasswordTouched] = useState(false);
+
   const navigate = useNavigate();
 
-  const handleDelete = async () => {
-    if (!password) {
-      setError('Password is required.');
-      return;
-    }
+  // Real-time validations
+  const isEmailMatching = typedEmail.trim().toLowerCase() === currentUserEmail.trim().toLowerCase();
+  const isPasswordNotEmpty = password.length > 0;
+
+  const emailValidationError = emailTouched && typedEmail.length > 0 && !isEmailMatching
+    ? 'Email does not match your currently registered email address.'
+    : null;
+
+  const passwordValidationError = passwordTouched && password.length > 0 && !isPasswordNotEmpty
+    ? 'Password is required.'
+    : null;
+
+  const isSubmitDisabled = !isEmailMatching || !isPasswordNotEmpty || isLoading;
+
+  const handleDelete = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!isEmailMatching || !isPasswordNotEmpty) return;
 
     try {
       setIsLoading(true);
       setError(null);
-
       await userService.deleteAccount({ password });
-    } catch {
-      setError('Error deleting account. Please try again.');
-    } finally {
-      setIsLoading(false);
       localStorage.removeItem('token');
       navigate('/login');
+    } catch (err) {
+      setError(getErrorMessage(err, 'Error deleting account. Please try again.'));
+      setIsLoading(false);
     }
   };
 
-  return {
-    password,
-    setPassword,
-    isLoading,
-    error,
-    handleDelete,
-  };
-};
-
-export function DeleteAccountSection() {
-  const { password, setPassword, isLoading, error, handleDelete } = useDeleteAccount();
-
   return (
-    <div className="border border-danger rounded p-3">
-      <h3 className="text-danger h5 mb-3">Danger Zone</h3>
-      <p className="text-muted small mb-3">
-        Once you delete your account, there is no going back. Please be certain.
+    <div className="p-1">
+      <h3 className="h5 mb-2 text-danger fw-bold">Danger Zone</h3>
+      <p className="text-danger small fw-bold mb-4 bg-danger-subtle p-3 rounded border border-danger-subtle">
+        WARNING: This action is irreversible. Once you delete your account, all your data, portfolio, and settings will be permanently erased.
       </p>
 
-      <div className="mb-3">
-        <label htmlFor="delete-account-password" className="form-label small fw-bold">Confirm Password</label>
-        <input
-          type="password"
-          id="delete-account-password"
-          className={`form-control ${error ? 'is-invalid' : ''}`}
-          placeholder="Enter your password to confirm"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          disabled={isLoading}
-        />
-        {error && <div className="invalid-feedback">{error}</div>}
-      </div>
+      {error && <div className="alert alert-danger py-2 px-3 small mb-3">{error}</div>}
 
-      <button className="btn btn-danger w-100" onClick={handleDelete} disabled={isLoading}>
-        {isLoading ? (
-          <>
-            <output className="spinner-border spinner-border-sm me-2" aria-hidden="true"></output>
-            <span>Deleting...</span>
-          </>
-        ) : (
-          'Permanently Delete Account'
-        )}
-      </button>
+      <form onSubmit={handleDelete} noValidate>
+        <div className="mb-3">
+          <label htmlFor="delete-account-email" className="form-label small fw-bold mb-1">
+            Confirm Account Email Address
+          </label>
+          <input
+            type="email"
+            id="delete-account-email"
+            className={`form-control ${emailValidationError ? 'is-invalid' : ''}`}
+            value={typedEmail}
+            onChange={(e) => {
+              setTypedEmail(e.target.value);
+              setEmailTouched(true);
+            }}
+            onBlur={() => setEmailTouched(true)}
+            disabled={isLoading}
+            required
+          />
+          {emailValidationError && (
+            <div className="text-danger small mt-1" style={{ fontSize: '12px' }}>
+              {emailValidationError}
+            </div>
+          )}
+        </div>
+
+        <div className="mb-4">
+          <label htmlFor="delete-account-password" className="form-label small fw-bold mb-1">
+            Confirm Password
+          </label>
+          <input
+            type="password"
+            id="delete-account-password"
+            className={`form-control ${passwordValidationError ? 'is-invalid' : ''}`}
+            value={password}
+            onChange={(e) => {
+              setPassword(e.target.value);
+              setPasswordTouched(true);
+            }}
+            onBlur={() => setPasswordTouched(true)}
+            disabled={isLoading}
+            required
+          />
+          {passwordValidationError && (
+            <div className="text-danger small mt-1" style={{ fontSize: '12px' }}>
+              {passwordValidationError}
+            </div>
+          )}
+        </div>
+
+        <button 
+          type="submit" 
+          className="btn btn-outline-danger w-100" 
+          disabled={isSubmitDisabled}
+          style={{ minHeight: '44px' }}
+        >
+          {isLoading ? (
+            <>
+              <output className="spinner-border spinner-border-sm me-2" aria-hidden="true"></output>
+              <span>Deleting Account...</span>
+            </>
+          ) : (
+            'Permanently Delete Account'
+          )}
+        </button>
+      </form>
     </div>
   );
 }

--- a/client/src/components/AccountSettings/UpdateEmailForm.tsx
+++ b/client/src/components/AccountSettings/UpdateEmailForm.tsx
@@ -2,16 +2,37 @@ import React, { useState } from 'react';
 import userService from '../../services/userService';
 import { getErrorMessage } from '../../utils/errorHandler';
 
-export function UpdateEmailForm() {
+interface UpdateEmailFormProps {
+  currentEmail: string;
+  onSuccess: (newEmail: string) => void;
+}
+
+export function UpdateEmailForm({ currentEmail, onSuccess }: Readonly<UpdateEmailFormProps>) {
   const [email, setEmail] = useState('');
+  const [currentPassword, setCurrentPassword] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
+  const [emailTouched, setEmailTouched] = useState(false);
+  const [passwordTouched, setPasswordTouched] = useState(false);
+
+  // Real-time validation
+  const isEmailValid = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+  const isPasswordNotEmpty = currentPassword.trim().length > 0;
+
+  const emailValidationError = emailTouched && email.length > 0 && !isEmailValid 
+    ? 'Please enter a valid email address.' 
+    : null;
+  const passwordValidationError = passwordTouched && currentPassword.length > 0 && !isPasswordNotEmpty 
+    ? 'Password cannot be empty.' 
+    : null;
+
+  const isSubmitDisabled = !isEmailValid || !isPasswordNotEmpty || isLoading;
+
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
-    if (!email.trim()) {
-      setError('Email is required.');
+    if (!isEmailValid || !isPasswordNotEmpty) {
       return;
     }
 
@@ -20,9 +41,17 @@ export function UpdateEmailForm() {
       setError(null);
       setSuccessMessage(null);
 
-      const response = await userService.updateEmail({ email: email.trim() });
+      const response = await userService.updateEmail({ 
+        email: email.trim(),
+        currentPassword
+      });
+      
       setSuccessMessage(response.message || 'Email updated successfully.');
+      onSuccess(email.trim());
       setEmail('');
+      setCurrentPassword('');
+      setEmailTouched(false);
+      setPasswordTouched(false);
     } catch (err) {
       setError(getErrorMessage(err, 'Failed to update email. Please try again.'));
     } finally {
@@ -31,33 +60,77 @@ export function UpdateEmailForm() {
   };
 
   return (
-    <div className="border rounded p-3">
-      <h3 className="h5 mb-3 text-dark">Update Email</h3>
-      <p className="text-muted small mb-3">
+    <div className="p-1">
+      <h3 className="h5 mb-2 text-dark fw-bold">Update Email</h3>
+      <p className="text-muted small mb-4">
         Change the email address associated with your account.
       </p>
+
+      {currentEmail && (
+        <div className="mb-4 p-3 bg-light rounded border">
+          <span className="text-secondary small d-block mb-1">Current Email Address</span>
+          <strong className="text-dark fs-6">{currentEmail}</strong>
+        </div>
+      )}
 
       {error && <div className="alert alert-danger py-2 px-3 small mb-3">{error}</div>}
       {successMessage && <div className="alert alert-success py-2 px-3 small mb-3">{successMessage}</div>}
 
-      <form onSubmit={handleSubmit}>
+      <form onSubmit={handleSubmit} noValidate>
         <div className="mb-3">
-          <label htmlFor="update-email-input" className="form-label small fw-bold">
+          <label htmlFor="update-email-input" className="form-label small fw-bold mb-1">
             New Email Address
           </label>
           <input
             type="email"
             id="update-email-input"
-            className={`form-control ${error ? 'is-invalid' : ''}`}
-            placeholder="Enter new email"
+            className={`form-control ${emailValidationError ? 'is-invalid' : ''}`}
             value={email}
-            onChange={(e) => setEmail(e.target.value)}
+            onChange={(e) => {
+              setEmail(e.target.value);
+              setEmailTouched(true);
+            }}
+            onBlur={() => setEmailTouched(true)}
             disabled={isLoading}
             required
           />
+          {emailValidationError && (
+            <div className="text-danger small mt-1" style={{ fontSize: '12px' }}>
+              {emailValidationError}
+            </div>
+          )}
         </div>
 
-        <button type="submit" className="btn btn-primary w-100" disabled={isLoading}>
+        <div className="mb-4">
+          <label htmlFor="update-email-password" className="form-label small fw-bold mb-1">
+            Current Password
+          </label>
+          <input
+            type="password"
+            id="update-email-password"
+            className={`form-control ${passwordValidationError ? 'is-invalid' : ''}`}
+            value={currentPassword}
+            onChange={(e) => {
+              setCurrentPassword(e.target.value);
+              setPasswordTouched(true);
+            }}
+            onBlur={() => setPasswordTouched(true)}
+            disabled={isLoading}
+            required
+          />
+          {passwordValidationError && (
+            <div className="text-danger small mt-1" style={{ fontSize: '12px' }}>
+              {passwordValidationError}
+            </div>
+          )}
+        </div>
+
+        <button 
+          type="submit" 
+          className="btn btn-primary w-100" 
+          disabled={isSubmitDisabled}
+          style={{ minHeight: '44px' }}
+        >
           {isLoading ? (
             <>
               <output className="spinner-border spinner-border-sm me-2" aria-hidden="true"></output>

--- a/client/src/components/AccountSettings/UpdatePasswordForm.tsx
+++ b/client/src/components/AccountSettings/UpdatePasswordForm.tsx
@@ -10,15 +10,33 @@ export function UpdatePasswordForm() {
   const [error, setError] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
+  const [currentPasswordTouched, setCurrentPasswordTouched] = useState(false);
+  const [newPasswordTouched, setNewPasswordTouched] = useState(false);
+  const [confirmPasswordTouched, setConfirmPasswordTouched] = useState(false);
+
+  // Real-time validations
+  const isCurrentPasswordNotEmpty = currentPassword.trim().length > 0;
+  const isNewPasswordLongEnough = newPassword.length >= 6;
+  const isConfirmPasswordMatching = newPassword === confirmPassword;
+
+  const currentPasswordValidationError = currentPasswordTouched && !isCurrentPasswordNotEmpty
+    ? 'Current password is required.'
+    : null;
+
+  const newPasswordValidationError = newPasswordTouched && newPassword.length > 0 && !isNewPasswordLongEnough
+    ? 'Password must be at least 6 characters.'
+    : null;
+
+  const confirmPasswordValidationError = confirmPasswordTouched && confirmPassword.length > 0 && !isConfirmPasswordMatching
+    ? 'Passwords do not match.'
+    : null;
+
+  const isSubmitDisabled = !isCurrentPasswordNotEmpty || !isNewPasswordLongEnough || !isConfirmPasswordMatching || isLoading;
+
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
     setError(null);
     setSuccessMessage(null);
-
-    if (!currentPassword || !newPassword || !confirmPassword) {
-      setError('All fields are required.');
-      return;
-    }
 
     if (newPassword.length < 6) {
       setError('Password must be at least 6 characters.');
@@ -46,6 +64,9 @@ export function UpdatePasswordForm() {
       setCurrentPassword('');
       setNewPassword('');
       setConfirmPassword('');
+      setCurrentPasswordTouched(false);
+      setNewPasswordTouched(false);
+      setConfirmPasswordTouched(false);
     } catch (err) {
       setError(getErrorMessage(err, 'Failed to update password. Please try again.'));
     } finally {
@@ -54,65 +75,97 @@ export function UpdatePasswordForm() {
   };
 
   return (
-    <div className="border rounded p-3">
-      <h3 className="h5 mb-3 text-dark">Update Password</h3>
-      <p className="text-muted small mb-3">
+    <div className="p-1">
+      <h3 className="h5 mb-2 text-dark fw-bold">Update Password</h3>
+      <p className="text-muted small mb-4">
         Change the password associated with your account.
       </p>
 
       {error && <div className="alert alert-danger py-2 px-3 small mb-3">{error}</div>}
       {successMessage && <div className="alert alert-success py-2 px-3 small mb-3">{successMessage}</div>}
 
-      <form onSubmit={handleSubmit}>
+      <form onSubmit={handleSubmit} noValidate>
         <div className="mb-3">
-          <label htmlFor="current-password-input" className="form-label small fw-bold">
+          <label htmlFor="current-password-input" className="form-label small fw-bold mb-1">
             Current Password
           </label>
           <input
             type="password"
             id="current-password-input"
-            className="form-control"
-            placeholder="Enter current password"
+            className={`form-control ${currentPasswordValidationError ? 'is-invalid' : ''}`}
             value={currentPassword}
-            onChange={(e) => setCurrentPassword(e.target.value)}
+            onChange={(e) => {
+              setCurrentPassword(e.target.value);
+              setCurrentPasswordTouched(true);
+            }}
+            onBlur={() => setCurrentPasswordTouched(true)}
             disabled={isLoading}
             required
           />
+          {currentPasswordValidationError && (
+            <div className="text-danger small mt-1" style={{ fontSize: '12px' }}>
+              {currentPasswordValidationError}
+            </div>
+          )}
         </div>
 
         <div className="mb-3">
-          <label htmlFor="new-password-input" className="form-label small fw-bold">
+          <label htmlFor="new-password-input" className="form-label small fw-bold mb-1">
             New Password
           </label>
           <input
             type="password"
             id="new-password-input"
-            className={`form-control ${error && newPassword.length < 6 ? 'is-invalid' : ''}`}
-            placeholder="Enter new password (min. 6 chars)"
+            className={`form-control ${newPasswordValidationError ? 'is-invalid' : ''}`}
             value={newPassword}
-            onChange={(e) => setNewPassword(e.target.value)}
+            onChange={(e) => {
+              setNewPassword(e.target.value);
+              setNewPasswordTouched(true);
+            }}
+            onBlur={() => setNewPasswordTouched(true)}
             disabled={isLoading}
             required
           />
+          <div className="text-muted small mt-1" style={{ fontSize: '12px' }}>
+            Minimum of 6 characters
+          </div>
+          {newPasswordValidationError && (
+            <div className="text-danger small mt-1" style={{ fontSize: '12px' }}>
+              {newPasswordValidationError}
+            </div>
+          )}
         </div>
 
-        <div className="mb-3">
-          <label htmlFor="confirm-password-input" className="form-label small fw-bold">
+        <div className="mb-4">
+          <label htmlFor="confirm-password-input" className="form-label small fw-bold mb-1">
             Confirm New Password
           </label>
           <input
             type="password"
             id="confirm-password-input"
-            className={`form-control ${error && newPassword !== confirmPassword ? 'is-invalid' : ''}`}
-            placeholder="Confirm new password"
+            className={`form-control ${confirmPasswordValidationError ? 'is-invalid' : ''}`}
             value={confirmPassword}
-            onChange={(e) => setConfirmPassword(e.target.value)}
+            onChange={(e) => {
+              setConfirmPassword(e.target.value);
+              setConfirmPasswordTouched(true);
+            }}
+            onBlur={() => setConfirmPasswordTouched(true)}
             disabled={isLoading}
             required
           />
+          {confirmPasswordValidationError && (
+            <div className="text-danger small mt-1" style={{ fontSize: '12px' }}>
+              {confirmPasswordValidationError}
+            </div>
+          )}
         </div>
 
-        <button type="submit" className="btn btn-primary w-100" disabled={isLoading}>
+        <button 
+          type="submit" 
+          className="btn btn-primary w-100" 
+          disabled={isSubmitDisabled}
+          style={{ minHeight: '44px' }}
+        >
           {isLoading ? (
             <>
               <output className="spinner-border spinner-border-sm me-2" aria-hidden="true"></output>

--- a/client/src/components/ModalLayout.tsx
+++ b/client/src/components/ModalLayout.tsx
@@ -6,22 +6,24 @@ export interface ModalProps {
   title: string;
   onClose: () => void;
   children: React.ReactNode;
+  size?: 'sm' | 'lg' | 'xl';
 }
 
-export function Modal({ show, title, onClose, children }: Readonly<ModalProps>) {
+export function Modal({ show, title, onClose, children, size }: Readonly<ModalProps>) {
   if (!show) return null;
 
   return (
     <div className="modal d-block" style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}>
-      <div className="modal-dialog">
+      <div className={`modal-dialog ${size ? `modal-${size}` : ''}`}>
         <div className="modal-content">
-          <div className="modal-header">
+          <div className="modal-header align-items-center">
             <h5 className="modal-title">{title}</h5>
             <button
               type="button"
               className="btn-close"
               onClick={onClose}
               aria-label="Close"
+              style={{ minWidth: '44px', minHeight: '44px', padding: '12px' }}
             ></button>
           </div>
           <div className="modal-body">{children}</div>

--- a/client/src/services/userService.ts
+++ b/client/src/services/userService.ts
@@ -2,6 +2,7 @@ import api from './api';
 
 export interface UpdateEmailData {
   email: string;
+  currentPassword?: string;
 }
 
 export interface UpdatePasswordData {
@@ -13,10 +14,20 @@ export interface DeleteAccountData {
   password: string;
 }
 
+export interface UserProfile {
+  id: number;
+  email: string;
+}
+
 export interface UserResponse {
   message: string;
   email?: string;
 }
+
+const getProfile = async (): Promise<UserProfile> => {
+  const response = await api.get('/user/profile');
+  return response.data;
+};
 
 const updateEmail = async (emailData: UpdateEmailData): Promise<UserResponse> => {
   const response = await api.put('/user/email', emailData);
@@ -34,6 +45,7 @@ const deleteAccount = async (accountData: DeleteAccountData): Promise<UserRespon
 };
 
 const userService = {
+  getProfile,
   updateEmail,
   updatePassword,
   deleteAccount,

--- a/server/src/controllers/userController.js
+++ b/server/src/controllers/userController.js
@@ -8,12 +8,12 @@ const userController = {
   // @access Private
   updateEmail: async (req, res) => {
     try {
-      const emailInput = req.body.email;
+      const { email: emailInput, currentPassword } = req.body;
       const id = req.user.id;
 
       // 1. Validate input
-      if (!emailInput) {
-        return res.status(400).json({ message: 'Please provide email' });
+      if (!emailInput || !currentPassword) {
+        return res.status(400).json({ message: 'Please provide email and current password' });
       }
 
       const emailValidator = z.string().toLowerCase().trim().pipe(z.email()).safeParse(emailInput);
@@ -26,6 +26,12 @@ const userController = {
       const user = await User.findById(id);
       if (!user) {
         return res.status(404).json({ message: 'User not found' });
+      }
+
+      // Verify current password to prevent account hijacking
+      const isPasswordValid = await bcrypt.compare(currentPassword, user.password_hash);
+      if (!isPasswordValid) {
+        return res.status(401).json({ message: 'Invalid credentials' });
       }
 
       if (user.email === email) {
@@ -114,6 +120,23 @@ const userController = {
     } catch (err) {
       console.error(err);
       res.status(500).json({ message: 'Server error during account deletion' });
+    }
+  },
+
+  // @desc Get user profile details
+  // @route GET /api/users/profile
+  // @access Private
+  getProfile: async (req, res) => {
+    try {
+      const id = req.user.id;
+      const user = await User.findById(id);
+      if (!user) {
+        return res.status(404).json({ message: 'User not found' });
+      }
+      res.status(200).json({ id: user.id, email: user.email });
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: 'Server error during profile fetching' });
     }
   },
 };

--- a/server/src/routes/userRoutes.js
+++ b/server/src/routes/userRoutes.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const userController = require('../controllers/userController');
 const authMiddleware = require('../middlewares/authMiddleware');
 
+router.get('/profile', authMiddleware, userController.getProfile);
 router.put('/email', authMiddleware, userController.updateEmail);
 router.put('/password', authMiddleware, userController.updatePassword);
 router.delete('/account', authMiddleware, userController.deleteAccount);


### PR DESCRIPTION
Restructures the account settings modal into a Split View layout and introduces several security and validation improvements:

- Restructured Account Settings modal into a Split View layout with an 8px base spacing scale and 44px min-height targets.
- Added password check to email update form on the backend to prevent account hijacking.
- Added profile details fetching to dynamically match the currently logged-in user email.
- Implemented strict validations and real-time inline feedback for password and email forms.
- Added irreversible alert styling and cross-check input validations to Tab 3 (Danger Zone).