### PR TITLE
style(client): optimize calculations and implement design improvements in RebalanceDrawer

### DIFF
--- a/client/src/components/RebalanceDrawer.tsx
+++ b/client/src/components/RebalanceDrawer.tsx
@@ -168,11 +168,14 @@ export function RebalanceDrawer({ show, onClose }: Readonly<RebalanceDrawerProps
           {/* === STEP 2: RESULTS LIST === */}
           {step === 'RESULT' && result && (
             <div className="flex-grow-1 d-flex flex-column" style={{ minHeight: 0 }}>
-              <div className="alert alert-success shadow-sm mb-3 d-flex align-items-center flex-shrink-0">
-                <i className="bi bi-check-circle-fill fs-4 me-3"></i>
-                <div>
+              <div
+                className="alert alert-success shadow-sm mb-3 d-flex align-items-center flex-shrink-0 py-3 px-4"
+                style={{ borderRadius: '0.75rem' }}
+              >
+                <i className="bi bi-check-circle-fill fs-4 me-3 flex-shrink-0"></i>
+                <div style={{ lineHeight: '1.7' }}>
                   Plan calculated for an investment of <br />
-                  <strong>{formatMoney(result.contribution, result.mainCurrency)}</strong>.
+                  <span className="fs-5 fw-bold">{formatMoney(result.contribution, result.mainCurrency)}</span>
                 </div>
               </div>
 
@@ -187,16 +190,21 @@ export function RebalanceDrawer({ show, onClose }: Readonly<RebalanceDrawerProps
               ) : (
                 <>
                   <div className="overflow-auto flex-shrink-1 mb-3" style={{ minHeight: 0 }}>
-                    <h6 className="text-muted text-uppercase fw-bold mb-3">Recommended Trades</h6>
-                    <ul className="list-group shadow-sm rounded-3 overflow-hidden mb-1">
-                      {result.suggestions.map((item, index) => (
-                        <li
+                    <h6
+                      className="text-muted-dark text-uppercase fw-bold mb-3"
+                      style={{ fontSize: '0.75rem', letterSpacing: '0.05em' }}
+                    >
+                      Recommended Trades
+                    </h6>
+                    <div className="d-flex flex-column gap-2 mb-1">
+                      {result.suggestions.map((item) => (
+                        <div
                           key={item.assetId}
-                          className={`list-group-item p-3 d-flex justify-content-between align-items-center ${index % 2 === 0 ? 'bg-light' : 'bg-white'}`}
+                          className="drawer-card p-3 d-flex justify-content-between align-items-center"
                         >
                           <div>
                             <h5 className="fw-bold mb-1">{item.name}</h5>
-                            <div className="small text-muted d-flex gap-3">
+                            <div className="small text-muted-dark d-flex gap-3">
                               <span>
                                 Target: <strong>{item.targetPercentage}%</strong>
                               </span>
@@ -210,31 +218,31 @@ export function RebalanceDrawer({ show, onClose }: Readonly<RebalanceDrawerProps
                               + {formatMoney(item.amountToBuy, item.currency)}
                             </div>
                             <small
-                              className="text-muted text-uppercase"
-                              style={{ fontSize: '0.7rem' }}
+                              className="text-muted-dark text-uppercase fw-bold"
+                              style={{ fontSize: '0.7rem', letterSpacing: '0.02em' }}
                             >
                               to buy
                             </small>
                           </div>
-                        </li>
+                        </div>
                       ))}
-                    </ul>
+                    </div>
                   </div>
 
                   {/* Summary Section */}
-                  <div className="p-3 bg-primary-subtle border border-primary-subtle rounded-3 flex-shrink-0 shadow-sm">
+                  <div className="p-3 drawer-card-summary flex-shrink-0 shadow-sm">
                     <div
-                      className="text-muted text-uppercase fw-bold mb-2"
+                      className="text-muted-dark text-uppercase fw-bold mb-2"
                       style={{ fontSize: '0.75rem', letterSpacing: '0.05em' }}
                     >
                       Total Allocation
                     </div>
                     <div className="d-flex justify-content-between align-items-center mb-1">
-                      <span className="text-secondary small">Real (BRL)</span>
+                      <span className="text-muted-dark small fw-semibold">Real (BRL)</span>
                       <span className="fw-bold fs-5 text-dark">{formatMoney(totalBRL, 'BRL')}</span>
                     </div>
                     <div className="d-flex justify-content-between align-items-center">
-                      <span className="text-secondary small">Dolar (USD)</span>
+                      <span className="text-muted-dark small fw-semibold">Dolar (USD)</span>
                       <span className="fw-bold fs-5 text-dark">{formatMoney(totalUSD, 'USD')}</span>
                     </div>
                   </div>

--- a/client/src/components/RebalanceDrawer.tsx
+++ b/client/src/components/RebalanceDrawer.tsx
@@ -21,18 +21,22 @@ export function RebalanceDrawer({ show, onClose }: Readonly<RebalanceDrawerProps
   // Data State
   const [result, setResult] = useState<RebalanceResponse | null>(null);
 
-  // Totals calculations
-  const totalBRL = result?.suggestions
-    ? result.suggestions
-        .filter((item) => item.currency === 'BRL')
-        .reduce((sum, item) => sum + item.amountToBuy, 0)
-    : 0;
+  // Totals calculations (memoized to prevent recalculating on input keystrokes)
+  const totalBRL = React.useMemo(() => {
+    return result?.suggestions
+      ? result.suggestions
+          .filter((item) => item.currency === 'BRL')
+          .reduce((sum, item) => sum + item.amountToBuy, 0)
+      : 0;
+  }, [result]);
 
-  const totalUSD = result?.suggestions
-    ? result.suggestions
-        .filter((item) => item.currency === 'USD')
-        .reduce((sum, item) => sum + item.amountToBuy, 0)
-    : 0;
+  const totalUSD = React.useMemo(() => {
+    return result?.suggestions
+      ? result.suggestions
+          .filter((item) => item.currency === 'USD')
+          .reduce((sum, item) => sum + item.amountToBuy, 0)
+      : 0;
+  }, [result]);
 
   // Reset state automatically whenever the drawer opens
   useEffect(() => {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -6,6 +6,13 @@
     'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
   line-height: 1.5;
   font-weight: 400;
+
+  /* Custom variables for UI styling */
+  --app-success-color: #10b981; /* Modern Emerald green */
+  --app-success-bg: #ecfdf5; /* Light Emerald tint for background */
+  --app-success-border: #d1fae5; /* Emerald border tint */
+  --app-text-muted-dark: #495057; /* Darker gray for high-contrast labels */
+  --app-text-secondary-dark: #343a40; /* Darker secondary text */
 }
 
 body {
@@ -89,14 +96,7 @@ a:hover {
 
 /* --- THEME OVERRIDES & UTILITIES --- */
 
-/* Custom variables for UI styling */
-:root {
-  --app-success-color: #10b981; /* Modern Emerald green */
-  --app-success-bg: #ecfdf5; /* Light Emerald tint for background */
-  --app-success-border: #d1fae5; /* Emerald border tint */
-  --app-text-muted-dark: #495057; /* Darker gray for high-contrast labels */
-  --app-text-secondary-dark: #343a40; /* Darker secondary text */
-}
+
 
 /* Overriding Bootstrap alert-success to match Emerald theme */
 .alert-success {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -86,3 +86,65 @@ a:hover {
 .drawer.show {
   transform: translateX(0);
 }
+
+/* --- THEME OVERRIDES & UTILITIES --- */
+
+/* Custom variables for UI styling */
+:root {
+  --app-success-color: #10b981; /* Modern Emerald green */
+  --app-success-bg: #ecfdf5; /* Light Emerald tint for background */
+  --app-success-border: #d1fae5; /* Emerald border tint */
+  --app-text-muted-dark: #495057; /* Darker gray for high-contrast labels */
+  --app-text-secondary-dark: #343a40; /* Darker secondary text */
+}
+
+/* Overriding Bootstrap alert-success to match Emerald theme */
+.alert-success {
+  --bs-alert-bg: var(--app-success-bg) !important;
+  --bs-alert-border-color: var(--app-success-border) !important;
+  --bs-alert-color: var(--app-success-color) !important;
+}
+
+/* Overriding Bootstrap text-success to match Emerald theme */
+.text-success {
+  color: var(--app-success-color) !important;
+}
+
+/* Overriding Bootstrap btn-success to match Emerald theme */
+.btn-success {
+  background-color: var(--app-success-color) !important;
+  border-color: var(--app-success-color) !important;
+  color: #ffffff !important;
+}
+
+.btn-success:hover,
+.btn-success:focus,
+.btn-success:active {
+  background-color: #059669 !important; /* Emerald 600 */
+  border-color: #059669 !important;
+  box-shadow: 0 0 0 0.25rem rgba(16, 185, 129, 0.25) !important;
+}
+
+/* High contrast text overrides */
+.text-muted-dark {
+  color: var(--app-text-muted-dark) !important;
+}
+
+.text-secondary-dark {
+  color: var(--app-text-secondary-dark) !important;
+}
+
+/* Standardized Card layout for drawer items */
+.drawer-card {
+  background-color: #ffffff;
+  border: 1px solid #e9ecef;
+  border-radius: 0.75rem !important;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+}
+
+.drawer-card-summary {
+  background-color: rgba(13, 110, 253, 0.05) !important;
+  border: 1px solid rgba(13, 110, 253, 0.12) !important;
+  border-radius: 0.75rem !important;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+}


### PR DESCRIPTION
This pull request implements optimization and visual design improvements to the Rebalance Drawer: memoizing BRL/USD total calculations via React.useMemo, standardizing card border properties and border-radius to 0.75rem, unifying green success color hues under an Emerald color scheme, and adjusting the vertical line-height and padding of the top success banner.